### PR TITLE
#16 Bugfix - Don't support space char in base path

### DIFF
--- a/lib/commands/ember-cli-jsdoc.js
+++ b/lib/commands/ember-cli-jsdoc.js
@@ -8,7 +8,7 @@ module.exports = {
         var rsvp = require( 'rsvp' );
         var path = require( 'path' );
         var cmd = path.resolve( 'node_modules', 'ember-cli-jsdoc', 'node_modules', '.bin', 'jsdoc' );
-        cmd = cmd + ' -c jsdoc.json';
+        cmd = '\"' + cmd + '\"' + ' -c jsdoc.json';
         var chalk = require( 'chalk' );
 
         return new rsvp.Promise( function( resolve, reject ) {


### PR DESCRIPTION
On Windows, we need double curly quote for the path string in order to execute it as command
